### PR TITLE
Issue 32: correct analytic eqs

### DIFF
--- a/paper/main.qmd
+++ b/paper/main.qmd
@@ -189,7 +189,7 @@ F_{\text{cens}}(q) &= \mathbb{E}_{P_u \mid P_u \in [t_P, t_P + w_P]}[\Pr(T \leq 
 \end{aligned}
 $$
 
-For continuous random variables, expectations are calculated using integrals. This gives us:
+For the random variable $P$ with density $f_P$, the expectation can be calculated using an integral. This gives us:
 
 $$F_{\text{cens}}(q) = \int_{t_P}^{t_P + w_P} \Pr(T \leq q + t_P - p ) \cdot f_{P}(p) \, dp$$
 
@@ -209,9 +209,9 @@ As shown in @eq-cdfadj, solving for $F_{\text{cens}}$ also solves for the second
 
 #### Exponentially tilted primary event times
 
-In practice, censoring patterns can be complex, influenced by a variety of factors including circadian rhythms, weekday/weekend reporting differences, and changing epidemic dynamics. We simplify this complexity by modeling the primary event distribution within its censoring window using an exponentially tilted distribution:
+In practice, censoring patterns can be complex, influenced by a variety of factors including circadian rhythms, weekday/weekend reporting differences, and changing epidemic dynamics. We simplify this complexity by modeling the primary event distribution within its censoring window using an exponentially tilted distribution, as per  @eq-defP :
 
-$$f_P(t) \propto \exp(r t) \mathbb{1}_{[t_P, t_P + w_P]}(t)$$
+$$f_P(p) \propto \exp(r p) \mathbb{1}_{[t_P, t_P + w_P]}(p)$$
 
 where $r$ controls the growth rate (positive values) or decay rate (negative values) of events within the window. This captures the key feature that during epidemic growth, events are more likely to occur near the end of their censoring windows, while during decline, they occur closer to the beginning.
 
@@ -227,15 +227,20 @@ $$F_{\text{cens}}(q) = \int_{0}^{w_P} F_T(q - u) \cdot \frac{1}{w_P} \, du = \fr
 
 This integral can be evaluated using integration by parts, transforming it into:
 
-$$F_{\text{cens}}(q) = F_T(q) + \frac{1}{w_P} \left[ \int_q^{q+w_P} f_T(z) (z-q) \, dz \right]$$
+$$
+\begin{aligned}
+F_{\text{cens}}(q) &= F_T(q-w_P) + \frac{1}{w_P} \int_0^{w_P} u~ f_T(q-u)\, du \\
+&= F_T(q-w_P) + \frac{1}{w_P} \int_{q-w_P}^{q} \left( q - z \right)~ f_T(z)  \, dz
+\end{aligned}
+$$ {#eq-soln}
 
 #### The role of partial expectation in analytical solutions
 
-Here, we encounter what's known as the partial expectation of the delay distribution:
+In equation @eq-soln, we encounter what's known as the partial expectation of the delay distribution:
 
-$$\int_q^{q+w_P} z \cdot f_T(z) \, dz$$
+$$\int_{q-w_P}^{q} z ~ f_T(z) \, dz$$
 
-This partial expectation calculates the mean contribution from values within the interval [q, q+w_P]. This relationship enables us to develop analytical solutions that avoid numerical integration for distributions with closed-form partial expectations.
+This partial expectation calculates the contribution to the mean value of delay $T$ from values within the interval $[q-w_P, q]$. Whenever the mean of $T$ has a closed form analytic solution, the partial expectation also has an analytical solution. So for these distributions we can avoid numerical integration for distributions and use the closed-form expression for these partial expectations instead.
 
 #### Distributions with analytical solutions
 


### PR DESCRIPTION
This PR closes #32 .

The main change in this PR is correcting the main equation in the section "_Uniform primary event time as a special case_". This was inaccurate; the error probably arrived in swapping from the survival-type analysis in https://primarycensored.epinowcast.org/articles/analytic-solutions.html i.e. using the complementary cumulative distribution function $Q$.

The new form of the analytic solution is correct (for example doing the derivation in 3.3 of https://primarycensored.epinowcast.org/articles/analytic-solutions.html  gives same result).

Secondary change was changing a comment about continuous distributions have integral solutions (with a PDF). This is not strictly accurate (for example, the Cantor distribution is continuous but doesn't have a PDF), and whilst a small thing I've reworded since #32 is about correctness.

I have not reworded much otherwise, please add confusing language problems to #9 .